### PR TITLE
Upgrade dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,5 +31,5 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.ichi2.anki:api:1.1.0alpha4'
+    implementation 'com.ichi2.anki:api:1.1.0alpha6'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,8 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -18,10 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
     }
 }


### PR DESCRIPTION
The dependency change is just tracking the work in the Anki-Android repository, as separate commits. That was just to get the tree in shape for work

The main work is in [the final commit](https://github.com/ankidroid/apisample/commit/206b8a82804c20dac9791d865e6a16cf8d66657b)

The comment explains it, but to explain here: to solve the problem of background execution not working (https://github.com/ankidroid/Anki-Android/issues/4617) you can verify you get a "reasonable" (not-null && size >=1) list of decks from the API provider before doing anything, with a useful error message in case the list doesn't seem correct